### PR TITLE
Add macOS test to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,10 @@ jobs:
     name: Test
     needs: [update]
     if: needs.update.outputs.updated == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: cachix/install-nix-action@v13
         with:


### PR DESCRIPTION
Make the test job a matrix which runs on macOS in addition to Ubuntu before releasing.

I'm mostly adding this as a just-in-case sort of thing since the Nix repo [already tests both](https://github.com/NixOS/nix/blob/50a35860ee9237d341948437c5f70a7f0987d393/.github/workflows/test.yml#L59), but given people are using these releases in macOS CI, we might as well test them against to be sure.

See run at: https://github.com/lilyinstarlight/nix-unstable-installer/actions/runs/1183532669