### PR TITLE
Bump cachix/install-nix-action from v13 to v14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       nix_release: ${{ steps.update.outputs.nix_release }}
       updated: ${{ steps.update.outputs.updated }}
     steps:
-      - uses: cachix/install-nix-action@v13
+      - uses: cachix/install-nix-action@v14
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
@@ -62,7 +62,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: cachix/install-nix-action@v13
+      - uses: cachix/install-nix-action@v14
         with:
           install_url: https://github.com/${{ github.repository }}/releases/download/${{ needs.update.outputs.nix_release }}/install
           extra_nix_config: |


### PR DESCRIPTION
Version 14 of cachix/install-nix-action has been released: https://github.com/cachix/install-nix-action/releases/tag/v14