### PR TITLE
update.rb: handle scheduled jobs with null buildstatus

### DIFF
--- a/update.rb
+++ b/update.rb
@@ -64,8 +64,8 @@ def get_eval(eval_id, skip_existing_tag = false)
     data = fetch_json("https://hydra.nixos.org/build/#{build_id}")
     job = data["job"]
 
-    if data["buildstatus"] > 0
-      puts "evaluation #{eval_id} has failed jobs"
+    if data["buildstatus"].nil? || data["buildstatus"] > 0
+      puts "evaluation #{eval_id} has failed or queued jobs"
       return :failure
     end
 


### PR DESCRIPTION
Hydra returns `buildstatus` as `null` when a build is scheduled but not in-progress. This handles that case and updates the output message to indicate queued (either scheduled or in-progress) builds.