### PR TITLE
update.rb: only check certain job prefixes for failure

### DIFF
--- a/update.rb
+++ b/update.rb
@@ -55,6 +55,7 @@ def get_eval(eval_id, skip_existing_tag = false)
   release_name = nil
 
   dist_jobs = ["installerScript", "binaryTarball.aarch64-darwin", "binaryTarball.aarch64-linux", "binaryTarball.i686-linux", "binaryTarball.x86_64-darwin", "binaryTarball.x86_64-linux"]
+  prefixes = ["build.", "installerScript", "binaryTarball.", "tests."]
 
   downloads = []
 
@@ -63,6 +64,10 @@ def get_eval(eval_id, skip_existing_tag = false)
   res["builds"].each do |build_id|
     data = fetch_json("https://hydra.nixos.org/build/#{build_id}")
     job = data["job"]
+
+    if prefixes.none? { |prefix| job.start_with? prefix }
+      next
+    end
 
     if data["buildstatus"].nil? || data["buildstatus"] > 0
       puts "evaluation #{eval_id} has failed or queued jobs"


### PR DESCRIPTION
The `buildStatic` Hydra jobs have been failing for a month already (see https://hydra.nixos.org/jobset/nix/master/evals) and their failure doesn't really impact this installer. I'm not sure whether they will be fixing those builds soon, so this PR only checks jobs that start with `build.`, `binaryTarball.`, `installerScript`, and `tests.` for failure.

Do you have any thoughts on this @zimbatm?

I don't mind either way really, but given unrelated jobs are currently preventing this repo from updating (when [nixpkgs has been updating nixUnstable](https://github.com/NixOS/nixpkgs/pull/138623)), I figured I'd make a PR for the functionality. Also any Ruby feedback is appreciated (as I worry this might have been an obtuse/non-obvious way to implement this).

Successful run: https://github.com/lilyinstarlight/nix-unstable-installer/actions/runs/1290936469
Corresponding release: https://github.com/lilyinstarlight/nix-unstable-installer/releases/tag/nix-2.4pre20210927_9c766a4