### PR TITLE
Bump cachix/install-nix-action from v14 to v15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       nix_release: ${{ steps.update.outputs.nix_release }}
       updated: ${{ steps.update.outputs.updated }}
     steps:
-      - uses: cachix/install-nix-action@v14
+      - uses: cachix/install-nix-action@v15
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
@@ -62,17 +62,16 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: cachix/install-nix-action@v14
+      - uses: cachix/install-nix-action@v15
         with:
           install_url: https://github.com/${{ github.repository }}/releases/download/${{ needs.update.outputs.nix_release }}/install
           extra_nix_config: |
-            experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Run nix-info
         run: |
-          nix shell nixpkgs#nix-info -c nix-info -m
+          nix run nixpkgs#nix-info -- -m
 
   release:
     name: Release

--- a/README.md.erb
+++ b/README.md.erb
@@ -34,12 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v11
+    - uses: cachix/install-nix-action@v15
       with:
         install_url: https://github.com/numtide/nix-unstable-installer/releases/download/<%= release_name %>/install
-        # Configure Nix to enable flakes
-        extra_nix_config: |
-          experimental-features = nix-command flakes
     # Run the general flake checks
     - run: nix flake check
     # Verify that the main program builds


### PR DESCRIPTION
Per [release notes](https://github.com/cachix/install-nix-action/releases/tag/v15), `experimental-features` is now set by default to `nix-command flakes` if not specified. You can verify this in the code at https://github.com/cachix/install-nix-action/blob/v15/lib/install-nix.sh#L21-L23

I also took the chance this time to update the example using cachix/install-nix-action in the README (well at least updating the template file -- it won't show in the actual readme until there stops being Hydra failures and Nix unstable updates again)

This PR also performs a drive-by change from "nix shell" to "nix run" for the
`nix-info` test, which I can move to a separate commit or PR separately if you'd like (it's just not necessary and mostly a nitpick semantic change since the behavior should be no different)

Successful Run: https://github.com/lilyinstarlight/nix-unstable-installer/actions/runs/1462934664
Corresponding Release: https://github.com/lilyinstarlight/nix-unstable-installer/releases/tag/nix-2.5pre20211026_5667822