### PR TITLE
Add Dependabot for GHA updates and template install-nix-action version in README.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/README.md.erb
+++ b/README.md.erb
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v15
+    - uses: cachix/install-nix-action@<%= install_nix_action_version %>
       with:
         install_url: https://github.com/numtide/nix-unstable-installer/releases/download/<%= release_name %>/install
     # Run the general flake checks


### PR DESCRIPTION
Related to discussion in #21 (but something I was planning to look into at some point anyway), I've added a quick implementation to enable dependabot and made it so the cachix/install-nix-action version used in the workflow is copied to README.md when generated. I'm open to better ideas of how to handle this, though, because this is clearly not quite ideal

I also fixed a (apparently harmless) typo in the `get_eval` invocation in `update.rb` that I happened to notice

Successful Run: https://github.com/lilyinstarlight/nix-unstable-installer/actions/runs/1495536686
Corresponding Release: https://github.com/lilyinstarlight/nix-unstable-installer/releases/tag/nix-2.5pre20211026_5667822
Release README.md: https://github.com/lilyinstarlight/nix-unstable-installer/blob/nix-2.5pre20211026_5667822/README.md
Dependabot PR Examples: https://github.com/lilyinstarlight/nix-unstable-installer/pulls?q=is%3Apr+author%3Aapp%2Fdependabot+

Quick question: Should we update the README.md file manually for now to update the cachix/install-nix-action version in the example, since it seems that older cachix/install-nix-action version now errors in GitHub Actions? (And also since I'm not sure when the Nix x86_64-darwin and aarch64-darwin flakey test failures will be fixed at https://hydra.nixos.org/jobset/nix/master/evals)