### PR TITLE
Minor update.rb and workflow fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: cachix/install-nix-action@v16
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          nix_path: nixpkgs=channel:nixpkgs-unstable
 
       - uses: actions/checkout@v2
         with:
@@ -67,7 +67,7 @@ jobs:
           install_url: https://github.com/${{ github.repository }}/releases/download/${{ needs.update.outputs.nix_release }}/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-          nix_path: nixpkgs=channel:nixos-unstable
+          nix_path: nixpkgs=channel:nixpkgs-unstable
 
       - name: Run nix-info
         run: |

--- a/README.md.erb
+++ b/README.md.erb
@@ -10,7 +10,7 @@ script so that it fetches them from GitHub instead.
 ## Latest release
 
 * Release: `<%= release_name %>`
-* Hydra eval: https://hydra.nixos.org/eval/<%= eval_id %>
+* Hydra eval: <https://hydra.nixos.org/eval/<%= eval_id %>>
 
 ## Usage
 

--- a/update.rb
+++ b/update.rb
@@ -70,7 +70,7 @@ def get_eval(eval_id, skip_existing_tag = false)
       next
     end
 
-    if data["buildstatus"].nil? || data["buildstatus"] > 0
+    if data["buildstatus"].nil? or data["buildstatus"] > 0
       puts "evaluation #{eval_id} has failed or queued jobs"
       return :failure
     end
@@ -120,7 +120,7 @@ def get_eval(eval_id, skip_existing_tag = false)
 
   # Get cachix/install-nix-action version for the README
   begin
-    install_nix_action_version = YAML.load_file(".github/workflows/release.yml")["jobs"]["update"]["steps"].find { |step| step["uses"].start_with? "cachix/install-nix-action@" }["uses"].split("@", 2).last
+    install_nix_action_version = YAML.load_file(".github/workflows/release.yml")["jobs"]["update"]["steps"].find { |step| step.has_key? "uses" and step["uses"].start_with? "cachix/install-nix-action@" }["uses"].split("@", 2).last
   rescue Errno::ENOENT
     install_nix_action_version = "master"
   end

--- a/update.rb
+++ b/update.rb
@@ -56,7 +56,7 @@ def get_eval(eval_id, skip_existing_tag = false)
   release_name = nil
 
   dist_jobs = ["installerScript", "binaryTarball.aarch64-darwin", "binaryTarball.aarch64-linux", "binaryTarball.i686-linux", "binaryTarball.x86_64-darwin", "binaryTarball.x86_64-linux"]
-  prefixes = ["build.", "installerScript", "binaryTarball.", "tests."]
+  prefixes = ["build.", "installerScript", "binaryTarball.", "tests.", "installTests."]
 
   downloads = []
 


### PR DESCRIPTION
This PR is a few minor fixes I've acculumated in my local repo. None of the issues that this fixes are currently causing any real problems (even if they conceivably could in the future), they're really just little nitpicks I've noticed in the code. I'm happy to split them up if you'd like or I can drop any of the changes that you don't want


### Changes:

* The code I added in #23 didn't check for the existence of the `"uses"` key before accessing it (and it's optional in GHA workflow schema), so I updated that to use `has_key?` first
* The CI tests were run against "nixos-unstable", but given it tests macOS as well and isn't using NixOS, I changed it to "nixpkgs-unstable" which is probably more appropriate
* I updated the script to require `installTests.*` to pass in Hydra in addition to the existing build prefixes the script looks for
* I made a minor change in the README template for link formatting


Successful run: https://github.com/lilyinstarlight/nix-unstable-installer/actions/runs/1638570430
Corresponding release: https://github.com/lilyinstarlight/nix-unstable-installer/releases/tag/nix-2.6.0pre20211228_ed3bc63


---


I've also two extra questions while I'm here:

1. Could you do a manual run after merging this (or before) to pull a new version with NixOS/nix#5833 fixed? My CI stuff is failing currently because of it

2. I thought about it when I first made a PR to this repo, but didn't ask at the time: What was the existing code in update.rb licensed under @zimbatm? All of the stuff I added can be under the same license as whatever you choose

Thank you!