### PR TITLE
More misc nits and fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,7 @@ jobs:
         run: |
           [ -n "$NIX_RELEASE" ] || (echo 'NIX_RELEASE empty or undefined' >&2; exit 1)
 
+          git pull origin "$GITHUB_REF"
           git cherry-pick origin/update/"$NIX_RELEASE"
           git push origin "$GITHUB_REF"
 

--- a/README.md.erb
+++ b/README.md.erb
@@ -33,7 +33,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@<%= install_nix_action_version %>
       with:
         install_url: https://github.com/numtide/nix-unstable-installer/releases/download/<%= release_name %>/install
@@ -46,6 +46,6 @@ jobs:
 ## Current release process
 
 * Run `./update.rb [eval_id]` (uses latest successful if no eval ID given)
-* Tag with the release name
+* Commit and tag with the release name
 * Push to GitHub
 * Create a new GitHub release and attach all files in the ./dist folder

--- a/update.rb
+++ b/update.rb
@@ -116,7 +116,15 @@ def get_eval(eval_id, skip_existing_tag = false)
   # Download files
   downloads.each do |job, build_id, filename|
     puts "downloading #{job}"
-    download("https://hydra.nixos.org/build/#{build_id}/download/1/#{filename}", "dist/#{filename}")
+
+    case job.split(".", 2).first
+    when "buildStatic"
+      dest = release_name + "-static-" + job.split(".", 2).last
+    else
+      dest = filename
+    end
+
+    download("https://hydra.nixos.org/build/#{build_id}/download/1/#{filename}", "dist/#{dest}")
   end
 
   # Rewrite the installer

--- a/update.rb
+++ b/update.rb
@@ -65,7 +65,7 @@ def get_eval(eval_id, skip_existing_tag = false)
     "buildStatic.x86_64-linux",
     "installerScript",
   ]
-  prefixes = ["build.", "installerScript", "binaryTarball.", "tests.", "installTests."]
+  extra_prefixes = ["build.", "buildStatic.", "tests.", "installTests."]
 
   downloads = []
 
@@ -75,7 +75,7 @@ def get_eval(eval_id, skip_existing_tag = false)
     data = fetch_json("https://hydra.nixos.org/build/#{build_id}")
     job = data["job"]
 
-    if prefixes.none? { |prefix| job.start_with? prefix }
+    if dist_jobs.none?(job) and extra_prefixes.none? { |prefix| job.start_with? prefix }
       next
     end
 


### PR DESCRIPTION
This PR has small nits and changes I've accumulated in my local repo over the last few months and a minor refactoring to make bc6d7fd actually download and add the static builds to the release. I manually tested the static build on the release tag and it seems to work

Let me know if I need to split these up or something could be improved!

If you don't have time within the next week to give it a quick review for any obvious issues @zimbatm, I'll probably merge this myself given the changes are fairly minor and do fix the static builds getting pushed to the release page (I'm happy to wait longer if you'd rather, however)

Run: https://github.com/lilyinstarlight/nix-unstable-installer/actions/runs/2770056934
Release: https://github.com/lilyinstarlight/nix-unstable-installer/releases/tag/nix-2.10.0pre20220728_86fcd4f