### PR TITLE
update,ci: add docker image logic

### DIFF
--- a/.ci/push-containers.sh
+++ b/.ci/push-containers.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+
+[ -n "$NIX_RELEASE" ] || (echo 'NIX_RELEASE empty or undefined' >&2; exit 1)
+
+image_tags=()
+
+for url in $(curl -sfL "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/tags/$NIX_RELEASE" |
+    jq -r '(.assets[] | select(.name | test("-container\\.tar\\.gz$"; "s"))).browser_download_url'); do
+  echo "downloading $url"
+  image_name="$(curl -sfL "$url" | docker load --quiet | sed -e 's/^Loaded image: //')"
+
+  image_filename="${url##*/}"
+  arch_release="${image_filename%-container.tar.gz}"
+  arch_name="ghcr.io/$GITHUB_REPOSITORY/nix:${arch_release#nix-}"
+
+  docker image tag "$image_name" "$arch_name"
+  docker image rm "$image_name"
+
+  image_tags+=("$arch_name")
+  echo "image tag: ${image_tags[-1]}"
+
+  docker image push "$arch_name"
+done
+
+docker manifest create "ghcr.io/$GITHUB_REPOSITORY/nix:${NIX_RELEASE#nix-}" "${image_tags[@]}"
+docker manifest push "ghcr.io/$GITHUB_REPOSITORY/nix:${NIX_RELEASE#nix-}"
+
+docker manifest create "ghcr.io/$GITHUB_REPOSITORY/nix:latest" "${image_tags[@]}"
+docker manifest push "ghcr.io/$GITHUB_REPOSITORY/nix:latest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: cachix/install-nix-action@v17
         with:
-          install_url: https://github.com/${{ github.repository }}/releases/download/${{ needs.update.outputs.nix_release }}/install
+          install_url: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ needs.update.outputs.nix_release }}/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           nix_path: nixpkgs=channel:nixpkgs-unstable
@@ -72,6 +72,24 @@ jobs:
       - name: Run nix-info
         run: |
           nix run nixpkgs#nix-info -- -m
+
+      - name: Pull container image
+        if: runner.os == 'Linux'
+        env:
+          NIX_RELEASE: ${{ needs.update.outputs.nix_release }}
+        run: |
+          [ -n "$NIX_RELEASE" ] || (echo 'NIX_RELEASE empty or undefined' >&2; exit 1)
+
+          curl -sfL "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/$NIX_RELEASE/$NIX_RELEASE-$(uname -m)-linux-container.tar.gz" |
+            docker load --quiet
+
+      - name: Run nix-info in container image
+        if: runner.os == 'Linux'
+        env:
+          NIX_RELEASE: ${{ needs.update.outputs.nix_release }}
+        run: |
+          docker run --rm "nix:${NIX_RELEASE#nix-}" \
+            nix --extra-experimental-features 'nix-command flakes' run nixpkgs#nix-info -- -m
 
   release:
     name: Release
@@ -109,3 +127,15 @@ jobs:
           NIX_RELEASE: ${{ needs.update.outputs.nix_release }}
         with:
           script: await require('.ci/mark-release.js')({require, context, core, github});
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Combine and push images to GitHub Container Registry
+        env:
+          NIX_RELEASE: ${{ needs.update.outputs.nix_release }}
+        run: .ci/push-containers.sh

--- a/README.md.erb
+++ b/README.md.erb
@@ -17,7 +17,7 @@ script so that it fetches them from GitHub instead.
 ### Systems
 
 ```sh
-sh <(curl -L https://github.com/numtide/nix-unstable-installer/releases/download/<%= release_name %>/install)
+sh <(curl -L <%= server_url %>/<%= repository %>/releases/download/<%= release_name %>/install)
 ```
 
 ### GitHub Actions
@@ -36,11 +36,17 @@ jobs:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@<%= install_nix_action_version %>
       with:
-        install_url: https://github.com/numtide/nix-unstable-installer/releases/download/<%= release_name %>/install
+        install_url: <%= server_url %>/<%= repository %>/releases/download/<%= release_name %>/install
     # Run the general flake checks
     - run: nix flake check
     # Verify that the main program builds
     - run: nix shell -c echo OK
+```
+
+### Docker
+
+```sh
+docker run --rm -ti ghcr.io/<%= repository %>/nix:<%= release_name.delete_prefix("nix-") %>
 ```
 
 ## Current release process


### PR DESCRIPTION
So this should "just work" and make a GHCR package after being merged and doing a run (manual or automatic), since it looks like GitHub automagics everything on their end now

I settled on using `docker` for the test and upload, but it did seem to work with both `docker` and `podman` (despite the `podman` in GHA being a little old)

I tested the image as downloaded from GHCR successfully on x86_64-linux, but I don't have an aarch64 system to test it on and I am just hoping the manifest list thing works (so the exact same image tag can be used on either architecture)

Additional drive-by changes include:
* Generalizing the repository URL
* Shifting around the `-static` in the release asset name since I've changed my mind since numtide/nix-unstable-installer#33 was merged (and it hasn't actually made it onto a release page yet)

Resolves #32

Run: https://github.com/lilyinstarlight/nix-unstable-installer/actions/runs/2800475830
Release: https://github.com/lilyinstarlight/nix-unstable-installer/releases/tag/nix-2.10.0pre20220804_7d1280b
Package: https://github.com/lilyinstarlight/nix-unstable-installer/pkgs/container/nix-unstable-installer%2Fnix

(Wow was this a pain to debug...)