### PR TITLE
update: check success of installerTests when looking for evals

### DIFF
--- a/update.rb
+++ b/update.rb
@@ -67,7 +67,7 @@ def get_eval(eval_id, skip_existing_tag = false)
     "dockerImage.x86_64-linux",
     "installerScript",
   ]
-  extra_prefixes = ["build.", "buildStatic.", "tests.", "installTests."]
+  extra_prefixes = ["build.", "buildStatic.", "tests.", "installTests.", "installerTests."]
 
   downloads = []
 


### PR DESCRIPTION
I see there are now tests in Hydra for the installer script on other Linux distros, so this PR just adds those to the checked builds when determining whether to use an eval